### PR TITLE
Set webhook as local only

### DIFF
--- a/custom_components/nuki_ng/nuki.py
+++ b/custom_components/nuki_ng/nuki.py
@@ -247,6 +247,7 @@ class NukiCoordinator(DataUpdateCoordinator):
             "bridge",
             hook_id,
             handler=self._make_bridge_hook_handler(),
+            local_only=True,
         )
 
     def _add_update(self, dev_id: str, update):


### PR DESCRIPTION
As it is only used for the bridge, the webhook should be local only
