### PR TITLE
[Opener] Improvements for continuous mode

### DIFF
--- a/custom_components/nuki_ng/binary_sensor.py
+++ b/custom_components/nuki_ng/binary_sensor.py
@@ -5,7 +5,7 @@ import logging
 
 from . import NukiEntity, NukiBridge
 from .constants import DOMAIN
-from .states import DoorSensorStates, LockStates
+from .states import DoorSensorStates, LockStates, LockModes
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -117,9 +117,9 @@ class LockState(NukiEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
-        current = LockStates(self.last_state.get(
-            "state", LockStates.UNDEFINED.value))
-        return current != LockStates.LOCKED
+        currentMode = LockModes(self.last_state.get("mode", LockModes.DOOR_MODE.value))
+        currentState = LockStates(self.last_state.get("state", LockStates.UNDEFINED.value))
+        return currentState != LockStates.LOCKED or currentMode != LockModes.DOOR_MODE
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/nuki_ng/lock.py
+++ b/custom_components/nuki_ng/lock.py
@@ -4,7 +4,7 @@ import logging
 
 from . import NukiEntity
 from .constants import DOMAIN
-from .states import LockStates
+from .states import LockStates, LockModes
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,12 +30,16 @@ class Lock(NukiEntity, LockEntity):
         return SUPPORT_OPEN
 
     @property
+    def lock_mode(self):
+        return self.last_state.get("mode", LockModes.DOOR_MODE.value)
+
+    @property
     def lock_state(self):
         return self.last_state.get("state", 255)
 
     @property
     def is_locked(self):
-        return LockStates(self.lock_state) == LockStates.LOCKED
+        return LockStates(self.lock_state) == LockStates.LOCKED and LockModes(self.lock_mode) == LockModes.DOOR_MODE
 
     @property
     def is_locking(self):

--- a/custom_components/nuki_ng/lock.py
+++ b/custom_components/nuki_ng/lock.py
@@ -54,6 +54,9 @@ class Lock(NukiEntity, LockEntity):
         return LockStates(self.lock_state) == LockStates.MOTOR_BLOCKED
 
     async def async_lock(self, **kwargs):
+        """Lock the opener also disable Continuos Mode"""
+        if self.coordinator.is_opener(self.device_id) and LockModes(self.last_state.get("mode", LockModes.DOOR_MODE.value)) == LockModes.CONTINUOUS_MODE:
+            await self.coordinator.action(self.device_id, "deactivate_continuous_mode")
         await self.coordinator.action(self.device_id, "lock")
 
     async def async_unlock(self, **kwargs):

--- a/custom_components/nuki_ng/states.py
+++ b/custom_components/nuki_ng/states.py
@@ -38,3 +38,8 @@ class DoorSecurityStates(BaseStates):
     CLOSED_AND_LOCKED = 1
     CLOSED_AND_UNLOCKED = 2
     OPEN = 3
+
+
+class LockModes(BaseStates):
+    DOOR_MODE = 2
+    CONTINUOUS_MODE = 3


### PR DESCRIPTION
- Actually when continuous mode is activated, the opener "lock" control and "locked" sensor shows as "locked". This PR check also continuous mode to determine the lock state
- Add configuration switch in opener to activate/deactivate continuous mode