### PR TITLE
Better protection of datetime conversion

### DIFF
--- a/custom_components/nuki_ng/sensor.py
+++ b/custom_components/nuki_ng/sensor.py
@@ -217,7 +217,7 @@ class LastUnlockUser(NukiEntity, SensorEntity):
         timestamp = self.coordinator.info_field(self.device_id, None, "last_log", "timestamp")
         action = self.coordinator.info_field(self.device_id, "unknown", "last_log", "action")
         return {
-            "timestamp": datetime.fromisoformat(timestamp) if not None else None,
+            "timestamp": datetime.fromisoformat(timestamp) if isinstance(timestamp, str) else None,
             "action": action,
         }
 


### PR DESCRIPTION
Fixes issue: Timestamp error #106

Log message appeared not very often. I had it running for a day without the log message.
Will continue to test for a few days...