### PR TITLE
Better Doorbell Suppression Support

### DIFF
--- a/custom_components/nuki_ng/__init__.py
+++ b/custom_components/nuki_ng/__init__.py
@@ -4,6 +4,7 @@ from .constants import DOMAIN, PLATFORMS
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import service, entity_registry, device_registry
+from homeassistant.helpers.entity import EntityCategory
 
 # from homeassistant.helpers import device_registry
 from homeassistant.helpers.update_coordinator import (
@@ -183,3 +184,21 @@ class NukiBridge(CoordinatorEntity):
             "model": model,
             "sw_version": versions.get("firmwareVersion"),
         }
+
+
+class NukiOpenerRingSuppressionEntity(NukiEntity):
+    
+    SUP_RING = 4
+    SUP_RTO = 2
+    SUP_CM = 1
+    
+    @property
+    def entity_category(self):
+        return EntityCategory.CONFIG
+    
+    @property
+    def doorbellSuppression(self):
+        return self.coordinator.info_field(self.device_id, 0, "openerAdvancedConfig", "doorbellSuppression")
+    
+    async def update_doorbell_suppression(self, new_value):
+        await self.coordinator.update_config(self.device_id, "openerAdvancedConfig", dict(doorbellSuppression=new_value))

--- a/custom_components/nuki_ng/constants.py
+++ b/custom_components/nuki_ng/constants.py
@@ -1,2 +1,2 @@
 DOMAIN = "nuki_ng"
-PLATFORMS = ["binary_sensor", "sensor", "lock", "switch", "button"]
+PLATFORMS = ["binary_sensor", "sensor", "lock", "switch", "button", "select"]

--- a/custom_components/nuki_ng/select.py
+++ b/custom_components/nuki_ng/select.py
@@ -1,0 +1,70 @@
+from email.policy import default
+from homeassistant.components.select import SelectEntity
+from homeassistant.helpers.entity import EntityCategory
+
+import logging
+
+from . import NukiEntity, NukiOpenerRingSuppressionEntity
+from .constants import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass,
+    entry,
+    async_add_entities
+):
+    entities = []
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    for dev_id in coordinator.data.get("devices", {}):
+        if coordinator.info_field(dev_id, -1, "openerAdvancedConfig", "doorbellSuppression")  >= 0:
+            entities.append(NukiOpenerRingSuppressionSelect(coordinator, dev_id))
+    async_add_entities(entities)
+    return True
+
+
+class NukiOpenerRingSuppressionSelect(NukiOpenerRingSuppressionEntity, SelectEntity):
+
+    SUP_OFF = 0
+    SUP_RING = NukiOpenerRingSuppressionEntity.SUP_RING
+    SUP_RTO = NukiOpenerRingSuppressionEntity.SUP_RTO
+    SUP_CM = NukiOpenerRingSuppressionEntity.SUP_CM
+
+    VALUES_TO_NAMES = {
+      # 0
+      SUP_OFF: 'Off',
+      # 4
+      SUP_RING: 'Ring',
+      # 2
+      SUP_RTO: 'Ring to Open',
+      # 1
+      SUP_CM: 'Continuous Mode',
+      # 4 + 2 == 6
+      SUP_RING | SUP_RTO: 'Ring & Ring to Open',
+      # 4 + 1 == 5
+      SUP_RING | SUP_CM: 'Ring & Continuous Mode',
+      # 2 + 1 == 3
+      SUP_RTO | SUP_CM: 'Ring to Open & Continuous Mode',
+      # 4 + 2 + 1 == 7
+      SUP_RING | SUP_RTO | SUP_CM: 'On (suppress all)',
+    }
+    NAMES_TO_VALUES = {v: k for k, v in VALUES_TO_NAMES.items()}
+
+    def __init__(self, coordinator, device_id):
+        super().__init__(coordinator, device_id)
+        self.set_id("select", "ring_suppression")
+        self.set_name("Ring suppression")
+        self._attr_icon = "mdi:bell-cancel"
+
+    @property
+    def current_option(self) -> str | None:
+        return self.VALUES_TO_NAMES[self.doorbellSuppression]
+
+    @property
+    def options(self) -> list[str]:
+        return list(self.NAMES_TO_VALUES.keys())
+
+    async def async_select_option(self, option: str) -> None:
+        await self.update_doorbell_suppression(self.NAMES_TO_VALUES[option])


### PR DESCRIPTION
Building on #126, I implemented and tested a select entity for doorbell suppression and separate switches for the different suppression settings. The switch entities are disabled by default so the user can choose to enable those if they prefer them over the select entity.

This also corrects the bit that has to be flipped for the previously existing switch. It seems the documentation from Nuki is slightly wrong and that's why the switch was changing the Continuous Mode ring suppression as seen [here](https://github.com/kvj/hass_nuki_ng/issues/76#issuecomment-1230800708).

I implemented this because I needed to have this functionality, but feel free to use my code in #126 instead.

Keep in mind that I'm not very familiar with git, GitHub, python or Home Assistant development, so I apologize if I did something wrong.