### PR TITLE
Gracefully mapping value to lock_state (#168)

### DIFF
--- a/custom_components/nuki_ng/sensor.py
+++ b/custom_components/nuki_ng/sensor.py
@@ -143,7 +143,7 @@ class DoorSecurityState(NukiEntity, SensorEntity):
     def get_state(self) -> DoorSecurityStates:
         lock_state = LockStates(self.last_state.get("state", LockStates.UNDEFINED.value))
         door_sensor_state = DoorSensorStates(
-            self.last_state.get("doorsensorState"))
+            self.last_state.get("doorsensorState"), DoorSensorStates.UNKNOWN.value)
 
         if lock_state == LockStates.LOCKED and door_sensor_state == DoorSensorStates.DOOR_CLOSED:
             return DoorSecurityStates.CLOSED_AND_LOCKED

--- a/custom_components/nuki_ng/sensor.py
+++ b/custom_components/nuki_ng/sensor.py
@@ -141,7 +141,7 @@ class DoorSecurityState(NukiEntity, SensorEntity):
         return str(self.get_state())
 
     def get_state(self) -> DoorSecurityStates:
-        lock_state = LockStates(self.last_state.get("state"))
+        lock_state = LockStates(self.last_state.get("state", LockStates.UNDEFINED.value))
         door_sensor_state = DoorSensorStates(
             self.last_state.get("doorsensorState"))
 


### PR DESCRIPTION
I added a default value if the state value in the dictionary is for whatever reason not mappable to LockStates. This is exactly what is already done in `binary_sensor.py:121`

Note: This does not fix the underlying issue, as the value shouldn't be `None` at all, or is this intentional @kvj? Nevertheless I still think the mapping should be handled gracefully.    