### PR TITLE
Update nuki.py

### DIFF
--- a/custom_components/nuki_ng/nuki.py
+++ b/custom_components/nuki_ng/nuki.py
@@ -58,7 +58,7 @@ class NukiInterface:
     def bridge_url(self, path: str, extra=None) -> str:
         extra_str = "&%s" % (urlencode(extra)) if extra else ""
         url = f"http://{self.bridge}:8080"
-        if re.match(".+\\:\d+$", self.bridge):
+        if re.match(r".+:\d+$", self.bridge):
             # Port inside
             url = f"http://{self.bridge}"
         if self.use_hashed:


### PR DESCRIPTION
Fix the following warning on 2024.2.0 dev:

```
 [py.warnings] /config/custom_components/nuki_ng/nuki.py:61: SyntaxWarning: invalid escape sequence '\d'
  if re.match(".+\\:\d+$", self.bridge):
```